### PR TITLE
Allow Library to accept JSON

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,13 @@ ConftestRun(code=1, results=[ConftestResult(filename='/Users/garethr/Documents/c
 False
 ```
 
+Passing in a dictionary to `json_input` is parsed as JSON then sent as stdin to the `confest` executable.
+```python
+from policykit import Conftest
+
+result = Conftest("policy").test(json_input={"foo": "bar"})
+print(result)
+```
 
 ## Action
 

--- a/policykit/cli.py
+++ b/policykit/cli.py
@@ -2,7 +2,6 @@ import glob
 from pathlib import Path
 
 import click
-
 from policykit import ConstraintTemplate
 
 COLORS = ["red", "green", "yellow", "blue", "magenta", "cyan"]

--- a/policykit/models.py
+++ b/policykit/models.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import List, Union
+from typing import Dict, List, Union
 
 import attr
 import yaml
@@ -15,10 +15,10 @@ def str_presenter(dumper, data):
 @dataclass_json
 @dataclass
 class ConftestResult:
-    filename: str
-    Warnings: List[str]
-    Failures: List[str]
-    Successes: List[str]
+    filename: Union[str, None]
+    warnings: List[Dict[str, Dict[str, str]]]
+    failures: List[Dict[str, Dict[str, str]]]
+    successes: List[Dict[str, Dict[str, str]]]
 
 
 @dataclass

--- a/policykit/test_models.py
+++ b/policykit/test_models.py
@@ -1,5 +1,4 @@
 import pytest  # type: ignore
-
 from policykit import ConstraintTemplate
 from policykit.models import ConftestRun
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,5 @@
 [pytest]
 addopts = --black --mypy --isort --verbose --cov=policykit --cov-report term-missing
+
+markers =
+  integration


### PR DESCRIPTION
Use Case: Allowing policykit to be used in Ansible. You can check Ansible module arguments against a policy.